### PR TITLE
reminderで受け取るactivityを単一のインスタンスになるように変更

### DIFF
--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -3,8 +3,8 @@
 class ReminderMailer < ApplicationMailer
   add_template_helper(DurationHelper)
 
-  def remind(user, activities)
-    @activities = activities
+  def remind(user, activity)
+    @activity = activity
     subject = I18n.t('reminder_mailer.remind.subject')
     mail(subject: subject, to: user.email)
   end

--- a/app/views/reminder_mailer/remind.html.slim
+++ b/app/views/reminder_mailer/remind.html.slim
@@ -2,6 +2,6 @@ section class="content"
   h1 class="title"
     = t('.title')
 
-  = render 'shared/activity_list', activities: @activities
+  = render 'shared/activity_list', activities: [@activity]
 
   == link_to t('.check'), utm_url(ENV.fetch('HACKARU_WEB_URL')), class: 'link-button'

--- a/app/views/reminder_mailer/remind.text.erb
+++ b/app/views/reminder_mailer/remind.text.erb
@@ -1,5 +1,3 @@
 <%= t('.title') %>
 
-<% @activities.each do |activity| %>
-- <%= activity.decorate.description %>: <%= hhmmss(activity.duration) %>
-<% end %>
+<%= @activity.decorate.description %>: <%= hhmmss(@activity.duration) %>

--- a/config/locales/views/reminder_mailer/remind/en.yml
+++ b/config/locales/views/reminder_mailer/remind/en.yml
@@ -1,6 +1,6 @@
 en:
   reminder_mailer:
     remind:
-      subject: 'These timers are still working'
-      title: 'These timers are still working'
+      subject: 'This timer is still working'
+      title: 'This timer is still working'
       check: 'Check it'

--- a/spec/mailers/previews/reminder_mailer_preview.rb
+++ b/spec/mailers/previews/reminder_mailer_preview.rb
@@ -4,7 +4,7 @@
 class ReminderMailerPreview < ActionMailer::Preview
   def remind
     user = FactoryBot.create(:user)
-    activities = FactoryBot.create_list(:activity, 2)
-    ReminderMailer.remind(user, activities)
+    activity = FactoryBot.create(:activity)
+    ReminderMailer.remind(user, activity)
   end
 end

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe ReminderMailer, type: :mailer do
   describe '#report' do
     let(:user) { create(:user) }
-    let(:activities) { create_list(:activity, 2, user: user) }
+    let(:activity) { create(:activity, user: user) }
 
     subject do
-      ReminderMailer.remind(user, activities)
+      ReminderMailer.remind(user, activity)
     end
 
     it 'send to user' do


### PR DESCRIPTION
アプリの仕様上、リマインド対象となる進行中のactivityは必ず一つになるので、ReminderMailerで複数インスタンスを想定する必要はない。

https://github.com/hackaru-app/hackaru-api/pull/269 の変更点を修正