### PR TITLE
Prevent unfinished activities in the future

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -13,6 +13,10 @@ class Activity < ApplicationRecord
     validates_datetime :stopped_at, on_or_before: -> { _1.started_at.next_year }
   end
 
+  with_options unless: :stopped_at do
+    validates_datetime :started_at, on_or_before: -> { Time.now }
+  end
+
   before_save :set_duration
   before_save :stop_other_workings, unless: :stopped_at
 


### PR DESCRIPTION
An active activity (ie. with empty stopped_at) with started_at in
the future cannot be stopped using the web or desktop app until its
started_at date is in the past. This is due to

    validates_datetime :started_at, on_or_before: :stopped_at

because if started_at > now and stopped_at = now then started_at cannot
be on or before stopped_at.

Currently, it is not possible to create such an activity using the web
or desktop app. However, it can be created using the REST api which will
then block the web and desktop app as mentioned above.

From a planing perspective it does not make sense to have an active activity
with started_at in the future as you should attempt to track the activities
that you are currently doing. Therefore this commit enforces that started_at
has to be either now or in the past.

The only exception is for activities with a known stopped_at date. This
enables you to plan eg. known meetings ahead.