### PR TITLE
Add zh-CN

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,7 @@ module HackaruApi
 
     config.action_mailer.preview_path = Rails.root.join('spec/mailers/previews')
 
-    config.i18n.available_locales = %i[ja en]
+    config.i18n.available_locales = %i[ja en zh-CN]
     config.i18n.load_path += Dir[
       Rails.root.join('config/locales/**/*.{rb,yml}')
     ]


### PR DESCRIPTION
This cooperates with https://github.com/hackaru-app/hackaru-web/pull/1319

I made no changes to `config/locales` as it looks like some views have been replaced by `hackaru-web`. Kindly let me know which is still being used.